### PR TITLE
Update uglychristmas.yaml

### DIFF
--- a/themes/uglychristmas.yaml
+++ b/themes/uglychristmas.yaml
@@ -6,7 +6,7 @@ uglychristmas:
   text-color: '#FFFFFF'
   text-medium-light-color: '#FFFFFF'
   text-medium-color: '#FFFFFF'
-  text-dark-color: '#F8CF29'
+  text-dark-color: "#476954"
   accent-color: '#F8CF29'
   accent-medium-color: '#F8CF29'
   background-color: '#165B33'


### PR DESCRIPTION
text-dark-color changed. The previous version used #476954 which is yellow. This made the entities icons look like they were always on. The new color is a green/grey for when entities are off. 